### PR TITLE
Adjust registration fee price and add carriers blocking to listing

### DIFF
--- a/remove_signup_nav.patch
+++ b/remove_signup_nav.patch
@@ -1,0 +1,60 @@
+diff --git a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+index 78c7601..98eea0b 100644
+--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
++++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+@@ -19,15 +19,7 @@ 
+ import css from './TopbarDesktop.module.css';
+ 
+-const SignupLink = () => {
+-  return (
+-    <NamedLink name="SignupPage" className={css.topbarLink}>
+-      <span className={css.topbarLinkLabel}>
+-        <FormattedMessage id="TopbarDesktop.signup" />
+-      </span>
+-    </NamedLink>
+-  );
+-};
++;
+ 
+ const LoginLink = () => {
+   return (
+@@ -169,7 +161,7 @@     />
+   ) : null;
+ 
+-  const signupLinkMaybe = isAuthenticatedOrJustHydrated ? null : <SignupLink />;
++  const signupLinkMaybe = null;
+   const loginLinkMaybe = isAuthenticatedOrJustHydrated ? null : <LoginLink />;
+ 
+   const searchFormMaybe = showSearchForm ? (
+diff --git a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+index 2800a03..f7bf6a5 100644
+--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
++++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+@@ -98,23 +98,17 @@   ) : null;
+ 
+   if (!isAuthenticated) {
+-    const signup = (
+-      <NamedLink name="SignupPage" className={css.signupLink}>
+-        <FormattedMessage id="TopbarMobileMenu.signupLink" />
+-      </NamedLink>
+-    );
+-
+-    const login = (
++const login = (
+       <NamedLink name="LoginPage" className={css.loginLink}>
+         <FormattedMessage id="TopbarMobileMenu.loginLink" />
+       </NamedLink>
+     );
+ 
+     const signupOrLogin = (
+-      <span className={css.authenticationLinks}>
+-        <FormattedMessage id="TopbarMobileMenu.signupOrLogin" values={{ signup, login }} />
+-      </span>
+-    );
++  <span className={css.authenticationLinks}>
++    {login}
++  </span>
++);
+     return (
+       <nav className={css.root}>
+         <div className={css.content}>

--- a/server/api/carrier.js
+++ b/server/api/carrier.js
@@ -1,0 +1,20 @@
+router.post('/mark-authority-verified', async (req, res) => {
+  try {
+    const { userId, verified, usdotNumber, authorityStatus } = req.body || {};
+    const trustedSdk = getTrustedSdk(req, res); // from ../api-util/sdk
+
+    await trustedSdk.users.updateProfile({
+      id: userId,
+      privateData: {
+        authorityVerified: !!verified,
+        ...(usdotNumber ? { usdotNumber } : {}),
+        ...(authorityStatus ? { authorityStatus } : {}),
+      },
+    });
+
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('mark-authority-verified failed', e);
+    res.status(500).json({ ok: false, error: 'Internal error' });
+  }
+});

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -15,13 +15,43 @@ module.exports = (req, res) => {
 
   const listingPromise = () => sdk.listings.show({ id: bodyParams?.params?.listingId });
 
-  Promise.all([listingPromise(), fetchCommission(sdk)])
-    .then(([showListingResponse, fetchAssetsResponse]) => {
+  Promise.all([listingPromise(), fetchCommission(sdk), sdk.currentUser.show()])
+    .then(([showListingResponse, fetchAssetsResponse, currentUserResponse]) => {
       const listing = showListingResponse.data.data;
       const commissionAsset = fetchAssetsResponse.data.data[0];
+      const currentUser = currentUserResponse?.data?.data;
 
       const { providerCommission, customerCommission } =
         commissionAsset?.type === 'jsonAsset' ? commissionAsset.attributes.data : {};
+
+      // ------------------ CARRIER AUTHORITY GUARD ------------------
+      // Determine which transition is being requested
+      const transitionName =
+        bodyParams?.transition ||
+        bodyParams?.params?.transition ||
+        (Array.isArray(bodyParams) ? bodyParams.find(p => p && p.transition)?.transition : null);
+
+      // Read flags from current user privateData
+      const pd = currentUser?.attributes?.profile?.privateData || {};
+      const isCarrier = pd.accountType === 'ProCarrier';
+      const isPaid = pd.registrationFeePaid === true;
+      const isAuthorityVerified = pd.authorityVerified === true; // set this true when USDOT/authority verified
+
+      // Which transitions to block until verified (adjust to your process if needed)
+      const BLOCKED_UNTIL_VERIFIED = ['transition/accept', 'transition/operator-accept'];
+
+      if (
+        isCarrier &&
+        isPaid &&
+        !isAuthorityVerified &&
+        BLOCKED_UNTIL_VERIFIED.includes(transitionName)
+      ) {
+        return res.status(403).json({
+          error: 'CARRIER_AUTHORITY_NOT_VERIFIED',
+          message: 'You must verify USDOT/authority before accepting hauls.',
+        });
+      }
+      // -------------------------------------------------------------
 
       lineItems = transactionLineItems(
         listing,

--- a/src/containers/ProviderSignupPage/ProviderSignupPage.js
+++ b/src/containers/ProviderSignupPage/ProviderSignupPage.js
@@ -2,7 +2,7 @@
 // FILE: src/containers/ProviderSignupPage/ProviderSignupPage.js
 // DESCRIPTION: U.S.-ONLY Provider/Carrier signup with FMCSA-focused compliance checks.
 // NOTE: After successful signup, this redirects to /register/payment
-//       for the $10 registration fee (Stripe Payment Intent flow).
+//       for the $4.99 registration fee (Stripe Payment Intent flow).
 // ===============================
 import React, { useMemo } from 'react';
 import { withRouter } from 'react-router-dom';
@@ -353,8 +353,8 @@ export const ProviderSignupPageComponent = props => {
         <p className={css.subhead}>
           U.S.-only signup with FMCSA-focused compliance checks and quick verification.
           <br />
-          <strong>Note:</strong> A one-time <strong>$10 registration fee</strong> is required right
-          after signup to continue to verification.
+          <strong>Note:</strong> A one-time <strong>$4.99 registration fee</strong> is required
+          right after signup to continue to verification.
         </p>
       </div>
 
@@ -389,7 +389,7 @@ export const ProviderSignupPageComponent = props => {
                 <span className={css.stepNum}>2</span> Add truck &amp; U.S. compliance details
               </li>
               <li>
-                <span className={css.stepNum}>3</span> Pay the one-time $10 fee &amp; verify docs
+                <span className={css.stepNum}>3</span> Pay the one-time $4.99 fee &amp; verify docs
               </li>
               <li>
                 <span className={css.stepNum}>4</span> Start bidding on shipments

--- a/src/containers/RegistrationPaymentPage/RegistrationPaymentPage.js
+++ b/src/containers/RegistrationPaymentPage/RegistrationPaymentPage.js
@@ -25,7 +25,7 @@ const API_BASE =
   (process.env.NODE_ENV === 'development' ? 'http://localhost:3500' : '');
 
 // --------- constants ----------
-const AMOUNT_CENTS = 1000; // $10
+const AMOUNT_CENTS = 499; // $4.99
 const CURRENCY = 'usd';
 const POST_PAYMENT_REDIRECT = process.env.REACT_APP_POST_PAYMENT_REDIRECT || '/profile-settings';
 
@@ -258,7 +258,7 @@ const PayInner = ({ onSuccess, dispatch, currentUser, clientSecret }) => {
       <PaymentElement options={{ layout: 'tabs' }} />
       {error ? <div className={css.error}>{error}</div> : null}
       <PrimaryButton type="submit" disabled={!stripe || status === 'confirming'}>
-        {status === 'confirming' ? 'Processing…' : 'Pay $10 Registration Fee'}
+        {status === 'confirming' ? 'Processing…' : 'Pay $4.99 Registration Fee'}
       </PrimaryButton>
     </form>
   );
@@ -341,7 +341,7 @@ export const RegistrationPaymentPageComponent = ({ currentUser = null, history, 
   return (
     <Page className={css.page}>
       <H1>Registration Fee</H1>
-      <H3>Pay a one-time $10 fee to continue to verification</H3>
+      <H3>Pay a one-time $4.99 fee to continue to verification</H3>
 
       {status === 'loading' && <div className={css.loading}>Preparing payment…</div>}
       {status === 'error' && <div className={css.error}>{error || 'Unable to start payment.'}</div>}

--- a/src/containers/RegistrationPaymentPage/RegistrationPaymentPage.js.bak
+++ b/src/containers/RegistrationPaymentPage/RegistrationPaymentPage.js.bak
@@ -166,7 +166,7 @@ const PayInner = ({ onSuccess, dispatch, currentUser, clientSecret }) => {
       <PaymentElement options={{ layout: 'tabs' }} />
       {error ? <div className={css.error}>{error}</div> : null}
       <PrimaryButton type="submit" disabled={!stripe || status === 'confirming'}>
-        {status === 'confirming' ? 'Processing…' : 'Pay $10 Registration Fee'}
+        {status === 'confirming' ? 'Processing…' : 'Pay $4.99 Registration Fee'}
       </PrimaryButton>
     </form>
   );
@@ -250,7 +250,7 @@ export const RegistrationPaymentPageComponent = ({ currentUser = null, history, 
   return (
     <Page className={css.page}>
       <H1>Registration Fee</H1>
-      <H3>Pay a one-time $10 fee to continue to verification</H3>
+      <H3>Pay a one-time $4.99 fee to continue to verification</H3>
 
       {status === 'loading' && <div className={css.loading}>Preparing payment…</div>}
       {status === 'error' && <div className={css.error}>{error || 'Unable to start payment.'}</div>}

--- a/src/containers/ShipperSignupPage/ShipperSignupPage.js
+++ b/src/containers/ShipperSignupPage/ShipperSignupPage.js
@@ -2,7 +2,7 @@
 // FILE: src/containers/ShipperSignupPage/ShipperSignupPage.js
 // DESCRIPTION: U.S.-ONLY signup page for Customers/Shippers using Sharetribe Flex components.
 // NOTE: After successful signup, this redirects to /register/payment
-//       for the $10 registration fee (Stripe Payment Intent flow).
+//       for the $4.99 registration fee (Stripe Payment Intent flow).
 // ===============================
 import React, { useMemo } from 'react';
 import { withRouter } from 'react-router-dom';
@@ -44,7 +44,10 @@ const USER_TYPE_OPTIONS = [
 // US-only
 const ORIGIN_REGION_OPTIONS = [{ key: 'us', label: 'United States (US-only accounts)' }];
 
-const CONTACT_PREFS = [{ key: 'email', label: 'Email' }, { key: 'phone', label: 'Phone' }];
+const CONTACT_PREFS = [
+  { key: 'email', label: 'Email' },
+  { key: 'phone', label: 'Phone' },
+];
 
 export const ShipperSignupPageComponent = props => {
   const onSubmit = async values => {
@@ -102,7 +105,7 @@ export const ShipperSignupPageComponent = props => {
       if (props.onSignup) {
         await props.onSignup(payload);
       }
-      // Redirect to the $10 registration fee step before verification
+      // Redirect to the $4.99 registration fee step before verification
       props.history.push('/register/payment');
       return undefined;
     } catch (e) {
@@ -125,8 +128,8 @@ export const ShipperSignupPageComponent = props => {
         <p className={css.subhead}>
           Create your account to post shipments, compare bids, and manage deliveries in one place.
           <br />
-          <strong>Note:</strong> A one-time <strong>$10 registration fee</strong> is required right
-          after signup to continue to verification.
+          <strong>Note:</strong> A one-time <strong>$4.99 registration fee</strong> is required
+          right after signup to continue to verification.
         </p>
       </div>
 
@@ -158,7 +161,7 @@ export const ShipperSignupPageComponent = props => {
                 <span className={css.stepNum}>1</span> Create your account
               </li>
               <li>
-                <span className={css.stepNum}>2</span> Pay the one-time $10 registration fee
+                <span className={css.stepNum}>2</span> Pay the one-time $4.99 registration fee
               </li>
               <li>
                 <span className={css.stepNum}>3</span> Post your shipment details

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -19,7 +19,7 @@ import CustomLinksMenu from './CustomLinksMenu/CustomLinksMenu';
 
 import css from './TopbarDesktop.module.css';
 
-const SignupLink = () => {
+/*const SignupLink = () => {
   return (
     <NamedLink name="SignupPage" className={css.topbarLink}>
       <span className={css.topbarLinkLabel}>
@@ -27,7 +27,7 @@ const SignupLink = () => {
       </span>
     </NamedLink>
   );
-};
+}; */
 
 const LoginLink = () => {
   return (
@@ -169,7 +169,8 @@ const TopbarDesktop = props => {
     />
   ) : null;
 
-  const signupLinkMaybe = isAuthenticatedOrJustHydrated ? null : <SignupLink />;
+  //const signupLinkMaybe = null;
+  const signupLinkMaybe = null;
   const loginLinkMaybe = isAuthenticatedOrJustHydrated ? null : <LoginLink />;
 
   const searchFormMaybe = showSearchForm ? (

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
@@ -98,11 +98,6 @@ const TopbarMobileMenu = props => {
   ) : null;
 
   if (!isAuthenticated) {
-    const signup = (
-      <NamedLink name="SignupPage" className={css.signupLink}>
-        <FormattedMessage id="TopbarMobileMenu.signupLink" />
-      </NamedLink>
-    );
 
     const login = (
       <NamedLink name="LoginPage" className={css.loginLink}>
@@ -110,11 +105,14 @@ const TopbarMobileMenu = props => {
       </NamedLink>
     );
 
-    const signupOrLogin = (
-      <span className={css.authenticationLinks}>
-        <FormattedMessage id="TopbarMobileMenu.signupOrLogin" values={{ signup, login }} />
-      </span>
-    );
+    /* const signupOrLogin = (
+  <span className={css.authenticationLinks}>
+    {login}
+  </span>
+);
+*/
+    const signupOrLogin = <span className={css.authenticationLinks}>{login}</span>;
+
     return (
       <nav className={css.root}>
         <div className={css.content}>


### PR DESCRIPTION
-  Add $4.99 One-Time Profile Setup Unlock for all accounts (ProShipper, ProCarrier, Guest Shipper)
- Auto-approve Shippers upon payment
- Allow Carriers access after payment but block haul acceptance until USDOT/authority verified
- Remove 'Individual' option for Carriers
- Carriers must select: Owner-Operator, Small Fleet, or Large Fleet
- Require USDOT number on carrier profile
- Remove Driver’s License Number requirement